### PR TITLE
feat: #118 로드맵당 퀘스트 업로드 상태 시 체크상태 변경 불가

### DIFF
--- a/quest-service/src/main/java/com/giunne/questservice/domain/questState/application/QuestStateService.java
+++ b/quest-service/src/main/java/com/giunne/questservice/domain/questState/application/QuestStateService.java
@@ -90,7 +90,17 @@ public class QuestStateService {
     }
 
     @Transactional
-    public void updateQuestProgress(UpdateQuestStateRequestDto dto) {
+    public void updateQuestProgress(Long questStateId,QuestProgress questProgress) {
+        QuestState questState = questStateRepository.findById(questStateId);
+        questState.updateQuestProgress(questProgress);
+        QuestState save = questStateRepository.save(questState);
+
+        questStateRepository.updateChildQuestOpen(save);
+
+    }
+
+    @Transactional
+    public void updateQuestProgressForTeacher(UpdateQuestStateRequestDto dto) {
         QuestState questState = questStateRepository.findById(dto.questStateId());
 
         QuestProgress questProgress = QuestProgress.from(dto.questProgress());
@@ -191,10 +201,7 @@ public class QuestStateService {
 
         if (questPost.getQuestPostProgressType() == QuestPostProgressType.UPLOAD ||
                 questPost.getQuestPostProgressType() == QuestPostProgressType.FAIL) {
-            updateQuestProgress(UpdateQuestStateRequestDto.builder()
-                    .questStateId(foundQuestState.getId())
-                    .questProgress(QuestProgress.CHECK.name())
-                    .build());
+            updateQuestProgress(foundQuestState.getId(),QuestProgress.CHECK);
 
             return;
         }
@@ -207,10 +214,7 @@ public class QuestStateService {
             if (quest.getNeedApproveCount().getValue() <= (foundQuestState.getCurrentApproveCount().getValue())) {
                 foundQuestState.getStarPoint().updateStartPoint(dto.starPoint());
                 questStateRepository.save(foundQuestState);
-                updateQuestProgress(UpdateQuestStateRequestDto.builder()
-                        .questStateId(foundQuestState.getId())
-                        .questProgress(QuestProgress.CONFIRM.name())
-                        .build());
+                updateQuestProgress(foundQuestState.getId(),QuestProgress.CONFIRM);
 
                 // 경험치 증가
                 Response<String> memberPointExperiencResponse = memberInfoClient.increaseExperience(questPost.getPlayer().getAvatarId(), quest.getRewardExp().getValue());
@@ -224,10 +228,7 @@ public class QuestStateService {
                     throw new IllegalArgumentException("포인트 증가 실패");
                 }
             } else {
-                updateQuestProgress(UpdateQuestStateRequestDto.builder()
-                        .questStateId(foundQuestState.getId())
-                        .questProgress(QuestProgress.CHECK.name())
-                        .build());
+                updateQuestProgress(foundQuestState.getId(),QuestProgress.CHECK);
             }
             return;
         }

--- a/quest-service/src/main/java/com/giunne/questservice/domain/questState/ui/QuestStateController.java
+++ b/quest-service/src/main/java/com/giunne/questservice/domain/questState/ui/QuestStateController.java
@@ -62,7 +62,7 @@ public class QuestStateController {
     })
     @PutMapping("/quest-progress")
     Response<String> savePlayerQuestStates2(@RequestBody UpdateQuestStateRequestDto dto) {
-        questStateService.updateQuestProgress(dto);
+        questStateService.updateQuestProgressForTeacher(dto);
         return Response.ok("성공");
     }
 

--- a/quest-service/src/test/java/com/giunne/questservice/domain/questState/repository/QuestStateRepositoryImplTest.java
+++ b/quest-service/src/test/java/com/giunne/questservice/domain/questState/repository/QuestStateRepositoryImplTest.java
@@ -31,12 +31,7 @@ class QuestStateRepositoryImplTest {
 
     @Test
     public void updateChildQuestOpen(){
-        UpdateQuestStateRequestDto updateQuestStateRequestDto = UpdateQuestStateRequestDto.builder()
-                .questStateId(3046L)
-                .questProgress(QuestProgress.CONFIRM.name())
-                .build();
-
-        questStateService.updateQuestProgress(updateQuestStateRequestDto);
+        questStateService.updateQuestProgress(3046L,QuestProgress.CONFIRM);
     }
 
 


### PR DESCRIPTION


## #️⃣ Issue Number
#118
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
- 로드맵당 퀘스트 업로드 상태 시 체크상태 변경 불가
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?


- [x] 버그 수정


## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
